### PR TITLE
Refactor: Use .get instead of .filter_by

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ class LoginResource(Resource):
 
 class UserShowResource(Resource):
     def patch(self, id=None):
-        user = User.query.filter_by(id=id)[0]
+        user = User.query.get(id)
         if user == None:
             return { "error": "could not find user" }, 404
 


### PR DESCRIPTION
### Function Checks:

```
[x] All tests passing
[x] Code runs locally
```

### Type of Change:

```
[ ] New Feature
[x] Bug fix
```

### Implementation/Fix Details:

```
sending an invalid ID in postman returned a 500 internal server error, found out it was because of the .filter_by(id=id) throwing an error if the ID was invalid. Changed it to .get(id) and now it returns the proper error message

```

### Dummy check: Did this break anything else?

```
[ ] Yes
[x] No
```

### Testing changes:

```
[x] No tests have been changed
[ ] Some tests have been changed
```

### Final checklist:

```
[x] I have reviewed my code
[ ] I have comments in my code for better understanding if needed
[x] I have tested my code
```

### Winking tomato man:
![winky](https://user-images.githubusercontent.com/94757433/179372967-8d64a160-7a36-4d04-89a0-17ed3cc84f3e.gif)
